### PR TITLE
index.twig now extends app.twig

### DIFF
--- a/resources/views/home/index.twig
+++ b/resources/views/home/index.twig
@@ -1,3 +1,5 @@
+{% extends 'app.twig' %}
+
 {% block content %}
     Hello from {{ appName }}!
 {% endblock %}


### PR DESCRIPTION
There was no `{% extends 'app.twig %}` tag in `resources/views/home/index.twig`. Therefore the base template was not being inherited. I've added the tag.