### PR TITLE
Upgrade slim/psr7 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "codecourse/slender",
     "description": "A slender starter structure for Slim",
-    "keywords": ["framework", "slim", "codecourse"],
+    "keywords": [
+        "framework",
+        "slim",
+        "codecourse"
+    ],
     "license": "MIT",
     "type": "project",
     "require": {
@@ -10,7 +14,7 @@
         "slim/twig-view": "3.0.0-alpha",
         "symfony/var-dumper": "^3.2",
         "vlucas/phpdotenv": "^2.4",
-        "slim/psr7": "^0.3.0",
+        "slim/psr7": "^1.1.0",
         "php-di/php-di": "^6.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -613,7 +613,7 @@
         },
         {
             "name": "slim/psr7",
-            "version": "0.3.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slimphp/Slim-Psr7.git",


### PR DESCRIPTION
The package causes issues with the request body for versions older than 1.0. slim php is unable to read the request body for any POST, PUT, ... requests when working off the current 2.0 release.