### PR TITLE
Fix namespace of container

### DIFF
--- a/app/Controllers/Controller.php
+++ b/app/Controllers/Controller.php
@@ -9,14 +9,14 @@ abstract class Controller
     /**
      * The container instance.
      *
-     * @var \Interop\Container\ContainerInterface
+     * @var Container
      */
     protected $c;
 
     /**
      * Set up controllers to have access to the container.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param Container $container
      */
     public function __construct(Container $container)
     {


### PR DESCRIPTION
PHP-DI has dropped support for container-interop and has replaced with [PSR-11](https://www.php-fig.org/psr/psr-11/).

I replaced `Interop\Container\ContainerInterface` namespace with `DI\Container` in this PR since you already type-hinted in controller constructor.

See also [this commit](https://github.com/container-interop/container-interop/commit/cdf1aa27c92b90a1e555794d599dff45be562479) and [PHP-DI migration guide](https://php-di.org/doc/migration/6.0.html#container-interop-and-psr-11).